### PR TITLE
Fix CI: Use npm install instead of npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Build packages
         run: npm run build
@@ -46,7 +46,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Build packages
         run: npm run build
@@ -68,7 +68,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Run tests
         run: npm run test
@@ -94,7 +94,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Build packages
         run: npm run build

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -59,7 +59,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Build all packages
         run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Build packages
         run: npm run build

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -24,7 +24,10 @@ export async function startDevServer(options: DevOptions) {
       resolve: {
         alias: {
           '@adidas/htmplar-core': path.resolve(process.cwd(), 'node_modules/@adidas/htmplar-core'),
-          '@adidas/htmplar-renderer': path.resolve(process.cwd(), 'node_modules/@adidas/htmplar-renderer'),
+          '@adidas/htmplar-renderer': path.resolve(
+            process.cwd(),
+            'node_modules/@adidas/htmplar-renderer'
+          ),
         },
       },
     });


### PR DESCRIPTION
Change from npm ci to npm install in all workflows to avoid platform-specific optional dependency issues.

npm ci requires package-lock.json to have ALL optional dependencies for all platforms, but when generated on macOS it's missing Linux platform-specific packages (esbuild, rollup, turbo binaries).

npm install is more forgiving and will fetch missing optional dependencies as needed.

Fixes GitHub Actions error:
"Missing: @esbuild/linux-x64@0.21.5 from lock file"

